### PR TITLE
fix(Vertex): Compile error when MTOON_OUTLINE_WIDTH_SCREEN

### DIFF
--- a/src/shaders/mtoon.vert
+++ b/src/shaders/mtoon.vert
@@ -168,7 +168,7 @@ void main(void) {
         vec4 projectedNormal = normalize(viewProjection * finalWorld * vec4(normalUpdated, 1.0));
         projectedNormal *= min(vertex.w, outlineScaledMaxDistance);
         projectedNormal.x *= aspect;
-        vertex.xy += 0.01 * outlineWidth * outlineTex * projectedNormal.xy * clamp(1 - abs(normalize(view * vec4(normalUpdated, 1.0).z)), 0.0, 1.0); // ignore offset when normal toward camera
+        vertex.xy += 0.01 * outlineWidth * outlineTex * projectedNormal.xy * clamp(1.0 - abs(normalize(view * vec4(normalUpdated, 1.0)).z), 0.0, 1.0); // ignore offset when normal toward camera
     }
 #endif
 


### PR DESCRIPTION
ERROR: 0:1077: 'normalize' : no matching overloaded function found
ERROR: 0:1077: '-' : wrong operand types - no operation '-' exists that takes a left-hand operand of type 'const int' and a right operand of type 'const mediump float' (or there is no acceptable conversion)
ERROR: 0:1077: 'clamp' : no matching overloaded function found