### PR TITLE
ci(circleci): ci uses node v14 instead of v12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
 jobs:
   build:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
     working_directory: ~/repo
     steps:
       - checkout
@@ -43,7 +43,7 @@ jobs:
 
   lint:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
     working_directory: ~/repo
     steps:
       - checkout
@@ -64,7 +64,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
     working_directory: ~/repo
     steps:
       - checkout


### PR DESCRIPTION
BREAKING CHANGE: drop support babylon.js v4.1.0. This version requires babylon.js v4.2.0. (no
support for babylon.js v5.0.0-dev)