### PR TITLE
fix: use original method of rendering outlines

### DIFF
--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -4,7 +4,6 @@ import { DirectionalLight } from '@babylonjs/core/Lights/directionalLight';
 import { HemisphericLight } from '@babylonjs/core/Lights/hemisphericLight';
 import { PointLight } from '@babylonjs/core/Lights/pointLight';
 import { ShadowGenerator } from '@babylonjs/core/Lights/Shadows/shadowGenerator';
-import { Material } from '@babylonjs/core/Materials/material';
 import { Texture } from '@babylonjs/core/Materials/Textures/texture';
 import { Color3, Vector3 } from '@babylonjs/core/Maths/math';
 import { CreateSphere } from '@babylonjs/core/Meshes/Builders/sphereBuilder';
@@ -178,9 +177,7 @@ async function main() {
 
     mtoonMaterials.forEach((mat, index) => {
         // MToonMaterial は glTF(右手座標) を考慮しているため、 CullMode をデフォルトから反転させる
-        mat.sideOrientation = Material.CounterClockWiseSideOrientation;
         mat.cullMode = 1;
-        mat.outlineCullMode = 2;
         const sphere = CreateSphere(`${mat.name}_Sphere`, {}, scene);
         sphere.position = new Vector3(-1.2 * index, 1.2, 0);
         sphere.receiveShadows = true;


### PR DESCRIPTION
bjs:
![スクリーンショット 2022-09-21 16 26 26](https://user-images.githubusercontent.com/28817604/191448393-807cdd8a-ef0e-476a-a118-b467fe2c3809.png)
unity:
![スクリーンショット 2022-09-21 16 41 32 2](https://user-images.githubusercontent.com/28817604/191448597-bc4dd93c-0076-45cb-b8c9-1b24adca2ef7.png)

This modification allows outlines to be drawn even if the same SubMesh is behind.
before:
![bjs-old](https://user-images.githubusercontent.com/28817604/191449400-11345b6f-1815-4161-afaf-6ce3a4061f71.png)
after:
![bjs-new](https://user-images.githubusercontent.com/28817604/191449423-e555c5f0-1d1f-44c2-9b62-c289ddf00c55.png)
reference:
![Unity](https://user-images.githubusercontent.com/28817604/191449514-3fc0d722-5e74-41d4-9ff4-af0f3acd5706.png)
